### PR TITLE
Replaced linear note maps with stringsNoteMap, inspired by LinnStrument

### DIFF
--- a/Launchpad.control.js
+++ b/Launchpad.control.js
@@ -164,7 +164,7 @@ function init()
       gridPage.mixerAlignedGrid = value.equals("Mixer");
    });
 
-   scaleMode = docState.getEnumSetting("Scale", "Drum/Key", ["Piano", "Drums L", "Drums S", "Ionian", "Dorian", "Phrygian", "Lydian", "Mixolydian", "Aeolian", "Locrian", "Linear14", "Linear25", "Linear34"], "Piano");
+   scaleMode = docState.getEnumSetting("Scale", "Drum/Key", ["Piano", "Drums L", "Drums S", "Ionian", "Dorian", "Phrygian", "Lydian", "Mixolydian", "Aeolian", "Locrian", "Strings"], "Piano");
    scaleMode.addValueObserver(function(value)
    {
       if (value.equals("Piano"))
@@ -214,17 +214,9 @@ function init()
          diatonicNoteMap.mode = 6;
          setActiveNoteMap(diatonicNoteMap);
       }
-      else if (value.equals("Linear14"))
+      else if (value.equals("Strings"))
       {
-         setActiveNoteMap(linear14Grid);
-      }
-      else if (value.equals("Linear25"))
-      {
-         setActiveNoteMap(linear25Grid);
-      }
-      else if (value.equals("Linear34"))
-      {
-         setActiveNoteMap(linear34Grid);
+         setActiveNoteMap(stringsNoteMap);
       }
    });
 

--- a/launchpad_notemap.js
+++ b/launchpad_notemap.js
@@ -485,60 +485,86 @@ diatonicNoteMap.getName = function()
 
 //----------------------------------------------------------------------------------------------------------
 
-var linear34Grid = new LinearGridNoteMap([3], 4);
-var linear25Grid = new LinearGridNoteMap([2], 5);
-var linear14Grid = new LinearGridNoteMap([1], 4);
-var noteMap23_12 = new LinearGridNoteMap([2, 3], 6);
-var noteMap13_12 = new LinearGridNoteMap([1, 3], 6);
+stringsNoteMap = new NoteMap();
+
+stringsNoteMap.offset = 47; // bottom-left corner note, default B2
+
+stringsNoteMap.getName = function() { 
+   return "Strings"; 
+}
+
+stringsNoteMap.cellToKey = function(x, y) {
+   var key = this.offset + (7-y) * 5 + x;
+   if (key < 0 || key > 127) return -1;
+   return key;
+};
+
+stringsNoteMap.drawCell = function(x, y, highlight) {
+   var key = this.cellToKey(x, y);
+
+   var colour;
+   if (key == -1) {
+      // non-existant note
+      colour = Colour.OFF 
+   } else if (noteOn[key]) {
+      // note currently being played
+      colour = Colour.RED_FULL;
+   } else if (key % 12 == 0) {
+      // C note
+      colour = Colour.AMBER_FULL;
+   } else if (! this.keyIsBlack(key)) {
+      // other white keys
+      colour = Colour.GREEN_FULL;
+   } else {
+      // black keys are not highlighted
+      colour = Colour.OFF;
+   }
+
+   setCellLED(x, y, colour);
+};
+
+stringsNoteMap.canScrollDown = function() { 
+   return this.offset < 127-35-11;
+}
+
+stringsNoteMap.canScrollUp = function() { 
+   return this.offset > -7+11;
+}
+
+stringsNoteMap.canScrollLeft = function() { 
+   return this.offset < 127-35;
+}
+
+stringsNoteMap.canScrollRight = function() { 
+   return this.offset > -7;
+}
+
+stringsNoteMap.scrollDown = function() {
+   if (!this.canScrollDown()) return;
+   this.offset += 12;
+   updateNoteTranlationTable();
+};
+
+stringsNoteMap.scrollUp = function() {
+   if (!this.canScrollUp()) return;
+   this.offset -= 12;
+   updateNoteTranlationTable();
+};
+
+stringsNoteMap.scrollLeft = function() {
+   if (!this.canScrollLeft()) return;
+   this.offset += 1;
+   updateNoteTranlationTable();
+};
+
+stringsNoteMap.scrollRight = function() {
+   if (!this.canScrollRight()) return;
+   this.offset -= 1;
+   updateNoteTranlationTable();
+};
 
 //----------------------------------------------------------------------------------------------------------
 
-linear14Grid.canScrollRight = function()
-{
-   return true;
-};
-
-linear14Grid.scrollRight = function()
-{
-   activeNoteMap = linear34Grid;
-   updateNoteTranlationTable();
-};
-
-linear34Grid.canScrollLeft = function()
-{
-   return true;
-};
-
-linear34Grid.scrollLeft = function()
-{
-   activeNoteMap = linear14Grid;
-   updateNoteTranlationTable();
-};
-
-linear34Grid.canScrollRight = function()
-{
-   return true;
-};
-
-linear34Grid.scrollRight = function()
-{
-   activeNoteMap = linear25Grid;
-   updateNoteTranlationTable();
-};
-
-linear25Grid.canScrollLeft = function()
-{
-   return true;
-};
-
-linear25Grid.scrollLeft = function()
-{
-   activeNoteMap = linear34Grid;
-   updateNoteTranlationTable();
-};
-
-//----------------------------------------------------------------------------------------------------------
-
-var noteMaps = [pianoNoteMap, largeDrumNoteMap, diatonicNoteMap, linear14Grid, null, null, null, null];
+var noteMaps = [pianoNoteMap, largeDrumNoteMap, diatonicNoteMap, stringsNoteMap, null, null, null, null];
 
 var activeNoteMap = pianoNoteMap;


### PR DESCRIPTION
I have replaced the 4th type of note input with a new stringsNoteMap, inspired by the "fourths strings layout" used on the LinnStrument, Ableton Push, Roli LightPad Block, and other devices and apps. The button lighting and the functions of the Up, Down, Left, and Right buttons in this layout have also been updated to ease playback.

I think this layout is becoming more common and is generally more useful and playable than the older linear note maps. In any case, I have left the LinearGridNoteMap class in the code.